### PR TITLE
Add Track.set() method

### DIFF
--- a/examples/README
+++ b/examples/README
@@ -38,17 +38,17 @@ In the next game iteration, your car will be at x, y - 1. world coordinates
 start at the top left of the screen. You would like to check if there is an
 obstacle at this location, and return the best action for this obstacle
 
-To check for obstacles, use the world.get_obstacle() function. This function
+To check for obstacles, use the world.get() function. This function
 accept a tuple (x, y) with the required location.
 
-    obstacle = world.get_obstacle((x, y - 1))
+    obstacle = world.get((x, y - 1))
 
 Note that if you try to access a position which is out of the racing track,
 this function will raise an IndexError. You must handle this exception when
 checking for obstacles:
 
     try:
-        obstacle = world.get_obstacle((x, y - 1))
+        obstacle = world.get((x, y - 1))
     except IndexError:
         # x, y - 1 is not a valid position
     else:

--- a/rtp/client/track.py
+++ b/rtp/client/track.py
@@ -50,7 +50,7 @@ class Track(component.Component):
 
     # Track interface
 
-    def get_obstacle(self, x, y):
+    def get(self, x, y):
         """ Return the obstacle in position x, y """
         self._validate_pos(x, y)
         return self._matrix[y][x]

--- a/rtp/client/world.py
+++ b/rtp/client/world.py
@@ -28,7 +28,7 @@ def generate_world(game):
             """ Return my car """
             return car
 
-        def get_obstacle(self, pos):
+        def get(self, pos):
             """
             Return the obstacle at position pos
 
@@ -37,6 +37,6 @@ def generate_world(game):
 
             Accessing a position out of the world bounds will raise IndexError exception.
             """
-            return game.track.get_obstacle(pos[0], pos[1])
+            return game.track.get(pos[0], pos[1])
 
     return World()

--- a/rtp/server/game.py
+++ b/rtp/server/game.py
@@ -137,7 +137,7 @@ class Game(object):
 
             # Now check if player hit any obstacle
 
-            obstacle = self.track.get_obstacle(player.x, player.y)
+            obstacle = self.track.get(player.x, player.y)
             if obstacle == obstacles.CRACK:
                 if player.action != actions.JUMP:
                     self.track.clear(player.x, player.y)

--- a/rtp/server/track.py
+++ b/rtp/server/track.py
@@ -21,9 +21,13 @@ class Track(object):
 
     # Track interface
 
-    def get_obstacle(self, x, y):
+    def get(self, x, y):
         """ Return the obstacle in position x, y """
         return self._matrix[y][x]
+
+    def set(self, x, y, obstacle):
+        """ Set obstacle in position x, y """
+        self._matrix[y][x] = obstacle
 
     def clear(self, x, y):
         """ Clear obstacle in position x, y """


### PR DESCRIPTION
For testing, we need a way to set obstacles at non-random location and
check if the player action is handled correctly.

To unify track interface names, get_obstable() was renamed to
get() in Track and World.

Get method will be more correct when we expose other cars location using
World.get().