### PR TITLE
Prefer players in their own lane when resolving collisions

### DIFF
--- a/rtp/common/config.py
+++ b/rtp/common/config.py
@@ -50,3 +50,4 @@ end_line_png = os.path.join(install_dir, '../res/end/final_flag.png')
 # Player
 
 max_players = 2
+cells_per_player = matrix_width / max_players

--- a/rtp/server/player.py
+++ b/rtp/server/player.py
@@ -20,11 +20,16 @@ class Player(object):
         """ Go to the next game state """
 
     def reset(self):
-        self.x = self.lane * 3 + 1              # | |0| | |1 | |
-        self.y = config.matrix_height / 3 * 2   # 1/3 of track
+        self.x = self.lane * config.cells_per_player + 1  # | |0| | |1 | |
+        self.y = config.matrix_height / 3 * 2             # 1/3 of track
         self.action = actions.NONE
         self.response_time = 1.0
         self.life = 0
+
+    def in_lane(self):
+        min_x = self.lane * config.cells_per_player
+        next_x = min_x + config.cells_per_player
+        return min_x <= self.x < next_x
 
     def __cmp__(self, other):
         return cmp((self.y, -self.life), (other.y, -other.life))

--- a/rtp/server/player_test.py
+++ b/rtp/server/player_test.py
@@ -1,0 +1,13 @@
+import player
+
+def test_in_lane():
+    p = player.Player("A", car=0, lane=0)
+    for x in (0, 1, 2):
+        p.x = x
+        assert p.in_lane()
+
+def test_not_in_lane():
+    p = player.Player("A", car=0, lane=1)
+    for x in (0, 1, 2):
+        p.x = x
+        assert not p.in_lane()

--- a/rtp/server/score.py
+++ b/rtp/server/score.py
@@ -9,10 +9,9 @@ def process(players, track):
     players: dict of player.Player objects
     track: track.Track object
     """
-    # Process first the leading drivers, preferring those with faster
-    # response time.
+    # Process first the player driving in its own lane
     sorted_players = sorted(players.itervalues(),
-                     key=lambda p: (p.y , p.response_time))
+                            key=lambda p: 0 if p.in_lane() else 1)
     positions = set()
 
     for player in sorted_players:
@@ -59,7 +58,7 @@ def process(players, track):
         # Fix up collisions
 
         if (player.x, player.y) in positions:
-            print 'fix up collisions for player', player.name
+            print 'player %s collision at %d,%d' % (player.name, player.x, player.y)
             if player.y < config.matrix_height - 1:
                 player.y += 1
             elif player.x > 0:

--- a/rtp/server/score_test.py
+++ b/rtp/server/score_test.py
@@ -264,94 +264,67 @@ class TestCollisions(object):
         players = {self.player1.name: self.player1, self.player2.name: self.player2}
         score.process(players, self.track)
 
-    def test_leading_player(self):
-        # Player 1 in 3,5
-        self.player1.x = 3
+    def test_player_in_lane_wins(self):
+        # Player 1 in its lane at 1,5
+        self.player1.x = 1
         self.player1.y = 5
         self.player1.life = 0
         self.player1.action = actions.NONE
-        # Player will pick the penguin in 3,6 and move up to 3,5
-        self.track.set(3, 6, obstacles.PENGUIN)
-        self.player2.x = 3
+        # Player 2 is not in its lane, trying to pick penguin at 1,6
+        self.track.set(1, 6, obstacles.PENGUIN)
+        self.player2.x = 1
         self.player2.y = 6
         self.player2.life = 0
         self.player2.action = actions.PICKUP
         self.process()
-        # Player 1 win because its y value is lower
-        assert self.player1.x == 3
+        # Player 1 win because it is in lane
+        assert self.player1.x == 1
         assert self.player1.y == 5
         assert self.player1.life == 0
         # Player 2 got more life but move back
-        assert self.player2.x == 3
+        assert self.player2.x == 1
         assert self.player2.y == 6
         assert self.player2.life == 1
 
-    def test_faster_player(self):
-        # Player 1 in 3,6
-        self.player1.x = 3
-        self.player1.y = 6
-        self.player1.life = 0
-        self.player1.action = actions.NONE
-        self.player1.response_time = 0.1
-        # Player 2 move from 4,6 to 3,6
-        self.player2.x = 4
-        self.player2.y = 6
-        self.player2.life = 0
-        self.player2.action = actions.LEFT
-        self.player2.response_time = 0.2
-        self.process()
-        # Player 1 win because its response time is lower
-        assert self.player1.x == 3
-        assert self.player1.y == 6
-        assert self.player1.life == 0
-        # Player 2 moved back
-        assert self.player2.x == 3
-        assert self.player2.y == 7
-        assert self.player2.life == 0
-
     def test_move_left(self):
-        # Player 1 in 4,8
-        self.player1.x = 4
+        # Player 1 in its lane at 1,8
+        self.player1.x = 1
         self.player1.y = 8
         self.player1.life = 0
         self.player1.action = actions.NONE
-        self.player1.response_time = 0.1
-        # Player 2 move from 3,8 to 4,8
-        self.player2.x = 3
+        # Player 2 trying to move to 1,8
+        self.player2.x = 0
         self.player2.y = 8
         self.player2.life = 0
         self.player2.action = actions.RIGHT
-        self.player2.response_time = 0.2
         self.process()
-        # Player 1 win because its response time is lower
-        assert self.player1.x == 4
+        # Player 1 win because it is in own lane
+        assert self.player1.x == 1
         assert self.player1.y == 8
         assert self.player1.life == 0
-        # Player 2 moved left, becuaus it is in the last row
-        assert self.player2.x == 3
+        # Player 2 moved left, first free cell
+        assert self.player2.x == 0
         assert self.player2.y == 8
         # TODO: decrease life?
         assert self.player2.life == 0
 
     def test_move_right(self):
-        # Player 1 in 0,8
+        # Player 1 in its lane at 0,8
         self.player1.x = 0
         self.player1.y = 8
         self.player1.life = 0
         self.player1.action = actions.NONE
-        self.player1.response_time = 0.1
         # Player 2 move from 1,8 to 0,8
         self.player2.x = 1
         self.player2.y = 8
         self.player2.life = 0
         self.player2.action = actions.LEFT
-        self.player2.response_time = 0.2
         self.process()
-        # Player 1 win because its response time is lower
+        # Player 1 win because it is in own lane
         assert self.player1.x == 0
         assert self.player1.y == 8
         assert self.player1.life == 0
-        # Player 2 moved right, becuaus it is in the last row and first cell
+        # Player 2 moved right, no other possible cell
         assert self.player2.x == 1
         assert self.player2.y == 8
         # TODO: decrease life?


### PR DESCRIPTION
Prvevsiously we would sort players by their y value and response time,
so leading/faster players took a position before other players, causing
other players to move back. This make the game too random, so the first
player getting a penguin (randomly) wins.

Now we let players driving it their lane to choose the next position,
and other players trying to pick other player penguin loose and moved
back.