### PR TITLE
Rename setup name to lowercase

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup
 
-setup(name='ROSE Project',
+setup(name='rose-project',
       version='0.1',
       license="GNU GPLv2+",
       description="game",


### PR DESCRIPTION
The previous name was creating a package name with an unusual name
including spaces in the package name.