### PR TITLE
More fair obstacle generation

### DIFF
--- a/rose/common/obstacles.py
+++ b/rose/common/obstacles.py
@@ -2,8 +2,7 @@
 
 import random
 
-NONE = -1
-ALL = CRACK, TRASH, PENGUIN, BIKE, WATER, BARRIER = tuple(range(6))
+ALL = NONE, CRACK, TRASH, PENGUIN, BIKE, WATER, BARRIER = tuple(range(-1, 6))
 
 
 def get_random_obstacle():

--- a/rose/server/track.py
+++ b/rose/server/track.py
@@ -40,8 +40,17 @@ class Track(object):
     # Private
 
     def _generate_row(self):
-        """ Generates new row with obstacles """
-        cell = random.randrange(config.matrix_width)
+        """
+        Generates new row with obstacles
+
+        Try to create fair but random obstacle stream. Each player get the same
+        obstacles, but in different cells.
+        """
         row = [obstacles.NONE] * config.matrix_width
-        row[cell] = obstacles.get_random_obstacle()
+        obstacle = obstacles.get_random_obstacle()
+        for lane in range(config.max_players):
+            low = lane * config.cells_per_player
+            high = low + config.cells_per_player
+            cell = random.choice(range(low, high))
+            row[cell] = obstacle
         return row


### PR DESCRIPTION
We used to generate one random obstacle per row at a random cell. This
created unfair conditions, causing random driver to win even if the
other driver code is equal or better.

Now we generate the same obstacle for both drivers. To make the track
more interesting, we randomize the cell for each lane.  To make the
track less crowded, NONE is now one of generated obstacles, creating an
empty row when selected.

Testing same driver code (not considering the lane yet) we see more fair
results.

This address #131 