### PR TITLE
Fix scoring when turning into other player lane

### DIFF
--- a/rose/server/score.py
+++ b/rose/server/score.py
@@ -9,15 +9,11 @@ def process(players, track):
     players: dict of player.Player objects
     track: track.Track object
     """
-    # Process first the player driving in its own lane
-    sorted_players = sorted(players.itervalues(),
-                            key=lambda p: 0 if p.in_lane() else 1)
-    positions = set()
 
-    for player in sorted_players:
+    # First handle right and left actions, since they may change in_lane
+    # status, used for resolving collisions.
 
-        # First move playe, keeping inside the track
-
+    for player in players.itervalues():
         if player.action == actions.LEFT:
             if player.x > 0:
                 player.x -= 1
@@ -25,8 +21,13 @@ def process(players, track):
             if player.x < config.matrix_width - 1:
                 player.x += 1
 
-        # Now check if player hit any obstacle
+    # Now handle obstacles, preferring players in their own lane.
 
+    sorted_players = sorted(players.itervalues(),
+                            key=lambda p: 0 if p.in_lane() else 1)
+    positions = set()
+
+    for player in sorted_players:
         obstacle = track.get(player.x, player.y)
         if obstacle == obstacles.CRACK:
             if player.action != actions.JUMP:

--- a/rose/server/score_test.py
+++ b/rose/server/score_test.py
@@ -286,6 +286,27 @@ class TestCollisions(object):
         assert self.player2.y == 6
         assert self.player2.life == 1
 
+    def test_after_turn(self):
+        # Player 1 in its lane at 2,5
+        self.player1.x = 2
+        self.player1.y = 5
+        self.player1.life = 0
+        self.player1.action = actions.NONE
+        # Player 2 in its lane, but after turning left, will not be in his lane.
+        self.player2.x = 3
+        self.player2.y = 5
+        self.player2.life = 0
+        self.player2.action = actions.LEFT
+        self.process()
+        # Player 1 win because it is in lane
+        assert self.player1.x == 2
+        assert self.player1.y == 5
+        assert self.player1.life == 0
+        # Player 2 got more life but move back
+        assert self.player2.x == 2
+        assert self.player2.y == 6
+        assert self.player2.life == 0
+
     def test_move_left(self):
         # Player 1 in its lane at 1,8
         self.player1.x = 1


### PR DESCRIPTION
We used to sort players by their in_lane status before processing
actions. This lead to possible wrong collision resolving, where a player
which is not in its lane *after* the turn won the collision.

Now we first handle RIGHT and LEFT actions, moving players into place,
and only then we sort players by in_lane status, and handle other
actions. If after the turn a player is not in its lane, it will lose a
collision with other player.