### PR TITLE
fix score details

### DIFF
--- a/rose/common/config.py
+++ b/rose/common/config.py
@@ -64,5 +64,3 @@ score_move_forward = 10
 score_move_backward = -10
 score_jump = 5
 score_brake = 4
-score_unnecessary_action = -3
-score_penguin_catch = 7

--- a/rose/server/score.py
+++ b/rose/server/score.py
@@ -54,11 +54,7 @@ def process(players, track):
             if player.action == actions.PICKUP:
                 track.clear(player.x, player.y)
                 player.y -= 1
-                player.score += config.score_penguin_catch
-        elif obstacle == obstacles.NONE:
-            player.score += config.score_move_forward
-            if player.action in (actions.JUMP, actions.BRAKE, actions.PICKUP):
-                player.score += config.score_unnecessary_action
+                player.score += config.score_move_forward
 
         # Here we can end the game when player gets out of
         # the track bounds. For now, just keep the player at the same
@@ -72,6 +68,7 @@ def process(players, track):
 
         if (player.x, player.y) in positions:
             print 'player %s collision at %d,%d' % (player.name, player.x, player.y)
+            player.score += config.score_move_backward
             if player.y < config.matrix_height - 1:
                 player.y += 1
             elif player.x > 0:


### PR DESCRIPTION
Instead of using penguin_catch we use move_forward.
Omit unnessecery_action_score.
Decrease score after collision.
Tests fix to fit the new score code.

Signed-off-by: Yaniv Bronhaim <ybronhei@redhat.com>